### PR TITLE
Remove redundant references to REXML

### DIFF
--- a/lib/esendex/message.rb
+++ b/lib/esendex/message.rb
@@ -1,6 +1,4 @@
-require 'rexml/document'
 require 'nokogiri'
-include REXML
 
 #  <message>
 #    <to>$TO</to>


### PR DESCRIPTION
Looks like REXML is no longer in use (since 841669c9), so removing these lines keeps things nice and tidy.
